### PR TITLE
Add rotate-skip-dedicated-windows and stop layouts from growing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ A number of preset layouts are available. These may be selected with the rotate-
 
 By replacing this value, you can circulate freely.
 
+#### `rotate-skip-dedicated-windows`
+
+Default value is `t`.
+
+When non-nil, rotate commands ignore dedicated windows.  This lets
+the package coexist cleanly with sidebar-style packages such as
+treemacs, neotree, or dired-sidebar, whose windows are typically
+dedicated.
+
+Set to `nil` to include dedicated windows in the rotation:
+
+```elisp
+(setq rotate-skip-dedicated-windows nil)
+```
+
 
 ## Preset layouts
 

--- a/rotate.el
+++ b/rotate.el
@@ -60,6 +60,15 @@
   :type '(repeat function)
   :group 'rotate)
 
+(defcustom rotate-skip-dedicated-windows t
+  "When non-nil, ignore dedicated windows in rotate commands.
+This lets the package coexist cleanly with sidebar-style packages
+such as treemacs, neotree, or dired-sidebar, whose windows are
+typically dedicated.  Set to nil to include dedicated windows in
+the rotation."
+  :type 'boolean
+  :group 'rotate)
+
 (defun rotate--count ()
   "Return the layout index for the selected frame."
   (or (frame-parameter nil 'rotate--count) 0))
@@ -182,8 +191,13 @@
     (delete-window)))
 
 (defun rotate--window-list ()
-  "Return the windows of the selected frame, excluding the minibuffer."
-  (window-list nil nil (minibuffer-window)))
+  "Return the windows of the selected frame, excluding the minibuffer.
+When `rotate-skip-dedicated-windows' is non-nil, also drop windows
+that are dedicated to their buffer."
+  (let ((windows (window-list nil nil (minibuffer-window))))
+    (if rotate-skip-dedicated-windows
+        (cl-remove-if #'window-dedicated-p windows)
+      windows)))
 
 (defun rotate--buffer-list ()
   "Return the buffers displayed in the selected frame."
@@ -191,16 +205,20 @@
 
 (defun rotate--refresh-window (proc)
   "Rebuild the layout using PROC and restore the existing buffers."
-  (unless (one-window-p)
-    (let ((window-num (count-windows))
-          (buffer-list (rotate--buffer-list))
-          (current-pos (cl-position (selected-window) (rotate--window-list))))
-      (delete-other-windows)
-      (funcall proc window-num)
-      (cl-loop for w in (rotate--window-list)
-               for b in buffer-list
-               do (set-window-buffer w b))
-      (select-window (nth current-pos (rotate--window-list))))))
+  (let* ((windows (rotate--window-list))
+         (selected (selected-window))
+         (current-pos (cl-position selected windows)))
+    (when (and (> (length windows) 1) current-pos)
+      (let ((window-num (length windows))
+            (buffer-list (rotate--buffer-list)))
+        (dolist (w windows)
+          (unless (eq w selected)
+            (delete-window w)))
+        (funcall proc window-num)
+        (cl-loop for w in (rotate--window-list)
+                 for b in buffer-list
+                 do (set-window-buffer w b))
+        (select-window (nth current-pos (rotate--window-list)))))))
 
 ;; Backward-compatible aliases for the pre-0.2.0 `rotate:foo' names.
 ;; They are built dynamically so the legacy symbols never appear as

--- a/test/rotate-test.el
+++ b/test/rotate-test.el
@@ -106,6 +106,54 @@ Return the list of buffers in window order."
      (rotate-layout)
      (should (= (rotate--count) 0)))))
 
+(ert-deftest rotate-test-skip-dedicated-windows-off ()
+  "By default dedicated windows are included in `rotate--window-list'."
+  (rotate-test--with-fresh-frame
+   (lambda ()
+     (rotate-test--make-windows 3)
+     (let ((rotate-skip-dedicated-windows nil)
+           (dedicated (frame-first-window)))
+       (set-window-dedicated-p dedicated t)
+       (unwind-protect
+           (should (= (length (rotate--window-list)) 3))
+         (set-window-dedicated-p dedicated nil))))))
+
+(ert-deftest rotate-test-layout-stable-with-protected-window ()
+  "Repeated `rotate-layout' calls must not keep growing the layout when
+a sidebar-style window protected by `no-delete-other-windows' is
+present.  Regression test for the bug where the count of windows
+increased by one on every invocation."
+  (rotate-test--with-fresh-frame
+   (lambda ()
+     (rotate-test--make-windows 3)
+     (let ((sidebar (frame-first-window)))
+       (set-window-parameter sidebar 'no-delete-other-windows t)
+       (set-window-dedicated-p sidebar t)
+       (unwind-protect
+           (let ((rotate-skip-dedicated-windows t))
+             ;; Make sure we are rotating from one of the eligible
+             ;; windows, not the sidebar.
+             (select-window (next-window sidebar))
+             (let ((before (count-windows)))
+               (dotimes (_ 5) (rotate-layout))
+               (should (= (count-windows) before))))
+         (set-window-dedicated-p sidebar nil)
+         (set-window-parameter sidebar 'no-delete-other-windows nil))))))
+
+(ert-deftest rotate-test-skip-dedicated-windows-on ()
+  "When `rotate-skip-dedicated-windows' is non-nil, dedicated windows are skipped."
+  (rotate-test--with-fresh-frame
+   (lambda ()
+     (rotate-test--make-windows 3)
+     (let ((rotate-skip-dedicated-windows t)
+           (dedicated (frame-first-window)))
+       (set-window-dedicated-p dedicated t)
+       (unwind-protect
+           (progn
+             (should (= (length (rotate--window-list)) 2))
+             (should-not (memq dedicated (rotate--window-list))))
+         (set-window-dedicated-p dedicated nil))))))
+
 (ert-deftest rotate-test-obsolete-aliases ()
   "Legacy `rotate:foo' names should still resolve to the new functions."
   (should (eq (symbol-function 'rotate:even-horizontal)


### PR DESCRIPTION
## Summary

Adds a `rotate-skip-dedicated-windows` defcustom (default `t`) so that
rotate commands ignore dedicated windows. This lets `rotate.el` coexist
cleanly with sidebar-style packages such as **treemacs**, **neotree**, and
**dired-sidebar**, whose windows are typically dedicated.

While here, this also fixes a long-standing layout-growth bug.

## Background

Issue #3 (by @aki-s) and PR #10 (by @basaran, building on @aki-s's
proposal) asked for dedicated-window awareness. This PR addresses the
core request — independently and with a much smaller surface — and
closes both threads.

## The fix

### New option: `rotate-skip-dedicated-windows`

| Value | Behaviour |
|---|---|
| `t` (default) | Dedicated windows are skipped entirely; rotation operates only on the remaining windows. |
| `nil` | Dedicated windows are treated like any other window (legacy behaviour). |

### Layout-growth bug

Previously, calling `rotate-layout` while a window with the
`no-delete-other-windows` parameter was present (treemacs, neotree,
dired-sidebar, etc.) made the layout grow by one window on every
invocation:

1. `delete-other-windows` deliberately **preserves** windows marked
   with `no-delete-other-windows`.
2. The subsequent layout proc then split the selected window into
   `window-num` panes from scratch, leaving the preserved sidebar
   plus a freshly-split layout — one more window than before.
3. Next call: same dance, one more window.

We now delete only the windows we are about to rebuild (using
`delete-window` in a loop) and bail out entirely if the selected
window is not part of the rotation, so the window count is stable
across repeated invocations.

## Tests

`test/rotate-test.el` adds three new ert tests:

- `rotate-test-skip-dedicated-windows-off` — dedicated windows are
  included when the option is `nil`.
- `rotate-test-skip-dedicated-windows-on` — dedicated windows are
  excluded when the option is non-nil.
- `rotate-test-layout-stable-with-protected-window` — regression test
  for the growth bug: 5 consecutive `rotate-layout` calls in a frame
  with a `no-delete-other-windows`-protected sidebar must not change
  the total window count.

All 12 tests pass locally; CI on Emacs 26.3 / 27.2 / 28.2 / 29.4 /
snapshot is expected to follow.

## Compatibility notes

Default changes from "include all windows" to "skip dedicated windows".
This is a behaviour change for users who:

- Run `rotate.el` in a frame with dedicated windows, **and**
- Want the dedicated windows to participate in the rotation.

That combination is rare; users who need the old behaviour can opt back
in with:

```elisp
(setq rotate-skip-dedicated-windows nil)
```

Closes #3.
Closes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)