### PR TITLE
Split the single window when rotate-layout is called with one window

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Rotate the positions of the window.
 #### `rotate-layout`
 
 Move a window to the next layout and rearrange the window to fit.
+If only one window is open, it is split first.
 
 **rotate-layout** 2 windows
 

--- a/rotate.el
+++ b/rotate.el
@@ -208,13 +208,13 @@ that are dedicated to their buffer."
   (let* ((windows (rotate--window-list))
          (selected (selected-window))
          (current-pos (cl-position selected windows)))
-    (when (and (> (length windows) 1) current-pos)
+    (when current-pos
       (let ((window-num (length windows))
             (buffer-list (rotate--buffer-list)))
         (dolist (w windows)
           (unless (eq w selected)
             (delete-window w)))
-        (funcall proc window-num)
+        (funcall proc (max 2 window-num))
         (cl-loop for w in (rotate--window-list)
                  for b in buffer-list
                  do (set-window-buffer w b))

--- a/test/rotate-test.el
+++ b/test/rotate-test.el
@@ -118,6 +118,22 @@ Return the list of buffers in window order."
            (should (= (length (rotate--window-list)) 3))
          (set-window-dedicated-p dedicated nil))))))
 
+(ert-deftest rotate-test-layout-from-single-window-splits ()
+  "`rotate-layout' should split the window when invoked with one window."
+  (rotate-test--with-fresh-frame
+   (lambda ()
+     (should (= (count-windows) 1))
+     (rotate-layout)
+     (should (>= (count-windows) 2)))))
+
+(ert-deftest rotate-test-even-horizontal-from-single-window-splits ()
+  "Individual layout commands should split when invoked with one window."
+  (rotate-test--with-fresh-frame
+   (lambda ()
+     (should (= (count-windows) 1))
+     (rotate-even-horizontal)
+     (should (= (count-windows) 2)))))
+
 (ert-deftest rotate-test-layout-stable-with-protected-window ()
   "Repeated `rotate-layout' calls must not keep growing the layout when
 a sidebar-style window protected by `no-delete-other-windows' is


### PR DESCRIPTION
## Summary

When invoked from a single-window frame, `rotate-layout` and the
individual layout commands were no-ops. That is the most natural
moment for a user to want a split, so this PR makes them DWIM:

- Drop the "more than one window" guard in `rotate--refresh-window`.
- Clamp the window count passed to the layout proc with `(max 2 ...)`
  so the layout proc always operates on at least two panes.

Calling `rotate-layout` with one window now applies the first layout
in `rotate-functions` (by default `rotate-even-horizontal`) and splits
the lone window in half. Subsequent calls cycle through the rest of
the layouts as before.

## Tests

Two new ert tests cover the new behaviour:

- `rotate-test-layout-from-single-window-splits` — `rotate-layout`
  from a single window ends with at least two windows.
- `rotate-test-even-horizontal-from-single-window-splits` — same for
  the individual layout commands.

All 14 tests pass locally; CI on Emacs 26.3 / 27.2 / 28.2 / 29.4 /
snapshot is expected to follow.

## Compatibility notes

Previously: `rotate-layout` was a no-op from one window.
Now: it splits and applies the first layout.

No existing user can have relied on the no-op behaviour for anything
useful, so this should be a strict improvement.

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)